### PR TITLE
Regularization: adding weight decay to Loss

### DIFF
--- a/api/src/main/java/ai/djl/training/loss/ElasticNetWeightDecay.java
+++ b/api/src/main/java/ai/djl/training/loss/ElasticNetWeightDecay.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package ai.djl.training.loss;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+
+
+/**
+ * {@code ElasticWeightDecay} calculates L1+L2 penalty of a set of parameters. Used for regularization.
+ * 
+ * <p>L loss is defined by \(L = \lambda \sum_i \vert W_i\vert + \lambda \sum_i \vert {W_i}^2\vert\).
+ */
+public class ElasticNetWeightDecay extends Loss {
+
+    private float lambda1;
+    private float lambda2;
+    private NDList parameters;
+
+    /** Calculates L2 weight decay for regularization. */
+    public ElasticNetWeightDecay(NDList parameters) {
+        this("ElasticNetWeightDecay", parameters);
+    }
+
+    /**
+     * Calculates L2 weight decay for regularization.
+     *
+     * @param name the name of the penalty
+     */
+    public ElasticNetWeightDecay(String name, NDList parameters) {
+        this(name, parameters, 1);
+    }
+
+    /**
+     * Calculates L2 weight decay for regularization.
+     *
+     * @param name the name of the penalty
+     * @param weight the weight to apply on penalty value, default 1
+     */
+    public ElasticNetWeightDecay(String name, NDList parameters, float lambda) {
+        super(name);
+        this.lambda1 = lambda;
+        this.lambda2 = lambda;
+        this.parameters = parameters;
+    }
+
+    /**
+     * Calculates L2 weight decay for regularization.
+     *
+     * @param name the name of the penalty
+     * @param weight the weight to apply on penalty value, default 1
+     */
+    public ElasticNetWeightDecay(String name, NDList parameters, float lambda1, float lambda2) {
+        super(name);
+        this.lambda1 = lambda1;
+        this.lambda2 = lambda2;
+        this.parameters = parameters;
+    }
+
+    private NDArray l1(NDArray w) {
+        return ((w.abs()).sum());
+    }
+
+    private NDArray l2(NDArray w) {
+        return ((w.square()).sum());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray evaluate(NDList label, NDList prediction) {
+
+        NDManager manager = parameters.getManager();
+        NDArray sum1 = manager.create(0.0f);
+        NDArray sum2 = manager.create(0.0f);
+        for(NDArray wi : parameters){
+            sum1.addi( l1(wi) );
+            sum2.addi( l2(wi) );
+        }
+        return sum1.muli(lambda1).addi( sum2.muli(lambda2));
+    }
+}

--- a/api/src/main/java/ai/djl/training/loss/L1WeightDecay.java
+++ b/api/src/main/java/ai/djl/training/loss/L1WeightDecay.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package ai.djl.training.loss;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+
+
+/**
+ * {@code L1WeightDecay} calculates L1 penalty of a set of parameters. Used for regularization.
+ * 
+ * <p>L1 loss is defined by \(L1 = \lambda \sum_i \vert W_i\vert\).
+ */
+public class L1WeightDecay extends Loss {
+
+    private float lambda;
+    private NDList parameters;
+
+    /** Calculates L1 weight decay for regularization. */
+    public L1WeightDecay(NDList parameters) {
+        this("L1WeightDecay", parameters);
+    }
+
+    /**
+     * Calculates L1 weight decay for regularization.
+     *
+     * @param name the name of the penalty
+     */
+    public L1WeightDecay(String name, NDList parameters) {
+        this(name, parameters, 1);
+    }
+
+    /**
+     * Calculates L1 weight decay for regularization.
+     *
+     * @param name the name of the penalty
+     * @param weight the weight to apply on penalty value, default 1
+     */
+    public L1WeightDecay(String name, NDList parameters, float lambda) {
+        super(name);
+        this.lambda = lambda;
+        this.parameters = parameters;
+    }
+
+    private NDArray l1(NDArray w) {
+        return ((w.abs()).sum());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray evaluate(NDList label, NDList prediction) {
+
+        NDManager manager = parameters.getManager();
+        NDArray sum = manager.create(0.0f);
+        for(NDArray wi : parameters){
+            sum.addi( l1(wi) );
+        }
+        return sum.muli(lambda);
+    }
+}

--- a/api/src/main/java/ai/djl/training/loss/L2WeightDecay.java
+++ b/api/src/main/java/ai/djl/training/loss/L2WeightDecay.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package ai.djl.training.loss;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+
+
+/**
+ * {@code L1WeightDecay} calculates L1 penalty of a set of parameters. Used for regularization.
+ * {@code L2WeightDecay} calculates L2 penalty of a set of parameters. Used for regularization.
+ * {@code ElasticWeightDecay} calculates L1+L2 penalty of a set of parameters. Used for regularization.
+ * 
+ * <p>L1 loss is defined by \(L1 = \lambda \sum_i \vert W_i\vert\).
+ * <p>L2 loss is defined by \(L2 = \lambda \sum_i \vert {W_i}^2\vert\).
+ */
+public class L2WeightDecay extends Loss {
+
+    private float lambda;
+    private NDList parameters;
+
+    /** Calculates L2 weight decay for regularization. */
+    public L2WeightDecay(NDList parameters) {
+        this("L2WeightDecay", parameters);
+    }
+
+    /**
+     * Calculates L2 weight decay for regularization.
+     *
+     * @param name the name of the penalty
+     */
+    public L2WeightDecay(String name, NDList parameters) {
+        this(name, parameters, 1);
+    }
+
+    /**
+     * Calculates L2 weight decay for regularization.
+     *
+     * @param name the name of the penalty
+     * @param weight the weight to apply on penalty value, default 1
+     */
+    public L2WeightDecay(String name, NDList parameters, float lambda) {
+        super(name);
+        this.lambda = lambda;
+        this.parameters = parameters;
+    }
+
+    private NDArray l2(NDArray w) {
+        return ((w.square()).sum());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray evaluate(NDList label, NDList prediction) {
+
+        NDManager manager = parameters.getManager();
+        NDArray sum = manager.create(0.0f);
+        for(NDArray wi : parameters){
+            sum.addi( l2(wi) );
+        }
+        return sum.muli(lambda);
+    }
+}

--- a/api/src/main/java/ai/djl/training/loss/Loss.java
+++ b/api/src/main/java/ai/djl/training/loss/Loss.java
@@ -239,6 +239,108 @@ public abstract class Loss extends Evaluator {
         return new HingeLoss(name, margin, weight);
     }
 
+    /**
+     * Returns a new instance of {@link L1WeightDecay} with default weight and name.
+     *
+     * @return a new instance of {@link L1WeightDecay}
+     */
+    public static L1WeightDecay l1WeightedDecay(NDList parameters) {
+        return new L1WeightDecay(parameters);
+    }
+
+    /**
+     * Returns a new instance of {@link L1WeightDecay} with default weight.
+     *
+     * @param name the name of the weight decay
+     * @return a new instance of {@link L1WeightDecay}
+     */
+    public static L1WeightDecay l1WeightedDecay(String name, NDList parameters) {
+        return new L1WeightDecay(name, parameters);
+    }
+
+    /**
+     * Returns a new instance of {@link L1WeightDecay}.
+     *
+     * @param name the name of the weight decay
+     * @param weight the weight to apply on weight decay value, default 1
+     * @return a new instance of {@link L1WeightDecay}
+     */
+    public static L1WeightDecay l1WeightedDecay(String name, float weight, NDList parameters) {
+        return new L1WeightDecay(name, parameters, weight);
+    }
+
+    /**
+     * Returns a new instance of {@link L2WeightDecay} with default weight and name.
+     *
+     * @return a new instance of {@link L2WeightDecay}
+     */
+    public static L2WeightDecay l2WeightedDecay(NDList parameters) {
+        return new L2WeightDecay(parameters);
+    }
+
+    /**
+     * Returns a new instance of {@link L2WeightDecay} with default weight.
+     *
+     * @param name the name of the weight decay
+     * @return a new instance of {@link L2WeightDecay}
+     */
+    public static L2WeightDecay l2WeightedDecay(String name, NDList parameters) {
+        return new L2WeightDecay(name, parameters);
+    }
+
+    /**
+     * Returns a new instance of {@link L2WeightDecay}.
+     *
+     * @param name the name of the weight decay
+     * @param weight the weight to apply on weight decay value, default 1
+     * @return a new instance of {@link L2WeightDecay}
+     */
+    public static L2WeightDecay l2WeightedDecay(String name, float weight, NDList parameters) {
+        return new L2WeightDecay(name, parameters, weight);
+    }
+
+    /**
+     * Returns a new instance of {@link ElasticNetWeightDecay} with default weight and name.
+     *
+     * @return a new instance of {@link ElasticNetWeightDecay}
+     */
+    public static ElasticNetWeightDecay elasticNetWeightedDecay(NDList parameters) {
+        return new ElasticNetWeightDecay(parameters);
+    }
+
+    /**
+     * Returns a new instance of {@link ElasticNetWeightDecay} with default weight.
+     *
+     * @param name the name of the weight decay
+     * @return a new instance of {@link ElasticNetWeightDecay}
+     */
+    public static ElasticNetWeightDecay elasticNetWeightedDecay(String name, NDList parameters) {
+        return new ElasticNetWeightDecay(name, parameters);
+    }
+
+    /**
+     * Returns a new instance of {@link ElasticNetWeightDecay}.
+     *
+     * @param name the name of the weight decay
+     * @param weight the weight to apply on weight decay values, default 1
+     * @return a new instance of {@link ElasticNetWeightDecay}
+     */
+    public static ElasticNetWeightDecay elasticNetWeightedDecay(String name, float weight, NDList parameters) {
+        return new ElasticNetWeightDecay(name, parameters, weight);
+    }
+
+    /**
+     * Returns a new instance of {@link ElasticNetWeightDecay}.
+     *
+     * @param name the name of the weight decay
+     * @param weight1 the weight to apply on weight decay L1 value, default 1
+     * @param weight2 the weight to apply on weight decay L2 value, default 1
+     * @return a new instance of {@link ElasticNetWeightDecay}
+     */
+    public static ElasticNetWeightDecay elasticNetWeightedDecay(String name, float weight1, float weight2, NDList parameters) {
+        return new ElasticNetWeightDecay(name, parameters, weight1, weight2);
+    }
+
     /** {@inheritDoc} */
     @Override
     public void addAccumulator(String key) {

--- a/integration/src/main/java/ai/djl/integration/tests/training/WeightDecayTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/training/WeightDecayTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.integration.tests.training;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.training.loss.Loss;
+import ai.djl.training.loss.L1WeightDecay;
+import ai.djl.training.loss.L2WeightDecay;
+import ai.djl.training.loss.ElasticNetWeightDecay;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class WeightDecayTest {
+
+    @Test
+    public void l1DecayTest() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray parameters1 = manager.create(new float[] {-1, -2, 3, 4, 5});    // 15
+            NDArray parameters2 = manager.create(new float[] {-1, -1, -1, -1, -1}); // 5 
+            // Not used
+            NDArray pred = manager.create(new float[] {});
+            NDArray label = manager.create(new float[] {});
+            // r = 2*(15 + 5) = 40
+            L1WeightDecay decay = Loss.l1WeightedDecay("", 2.0f, new NDList(parameters1, parameters2));
+            Assert.assertEquals(
+                    decay.evaluate(new NDList(label), new NDList(pred)).getFloat(), 40.0f);
+        }
+    }
+
+    @Test
+    public void l2DecayTest() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray parameters1 = manager.create(new float[] {-1, -2, 3, 4, 5});    // 55
+            NDArray parameters2 = manager.create(new float[] {-1, -1, -1, -1, -1}); // 5 
+            // Not used
+            NDArray pred = manager.create(new float[] {});
+            NDArray label = manager.create(new float[] {});
+            // r = 2*(55 + 5) = 120
+            L2WeightDecay decay = Loss.l2WeightedDecay("", 2.0f, new NDList(parameters1, parameters2));
+            Assert.assertEquals(
+                    decay.evaluate(new NDList(label), new NDList(pred)).getFloat(), 120.0f);
+        }
+    }
+
+    @Test
+    public void elasticNetDecayTest() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray parameters1 = manager.create(new float[] {-1, -2, 3, 4, 5});    
+            NDArray parameters2 = manager.create(new float[] {-1, -1, -1, -1, -1}); 
+            // Not used
+            NDArray pred = manager.create(new float[] {});
+            NDArray label = manager.create(new float[] {});
+            // r = L1 + L2 = 2*20 + 1*60 = 100
+            ElasticNetWeightDecay decay = Loss.elasticNetWeightedDecay("", 2.0f, 1.0f, new NDList(parameters1, parameters2));
+            Assert.assertEquals(
+                    decay.evaluate(new NDList(label), new NDList(pred)).getFloat(), 100.0f);
+        }
+    }
+
+    
+}


### PR DESCRIPTION
## Description ##

As per the discussion [here](https://github.com/awslabs/djl/discussions/769) I have:
* Added class for weigh decay: `L1WeightDecay`, `L2WeightDecay` and `ElasticNetWeightDecay`
* Added a test class `WeightDecayTest` with 3 tests (one for each class above)

All tests are in the loss package. Don't think this interferes with anything else in the project. I also did not find additional tests using `SimpleCompositeLoss` so I did not add these. 
